### PR TITLE
Исправлено не корректное отоброжение дней недели

### DIFF
--- a/date/calendar.php
+++ b/date/calendar.php
@@ -7,10 +7,11 @@
   // данная клетка календаря пуста).
   function makeCal($year, $month) {
     // Получаем номер дня недели для 1 числа месяца.
-    $wday = date('N');
+    $getdate = getdate(mktime(0, 0, 0, $month, 1, $year));
+    $wday = $getdate["wday"];
     // Начинаем с этого числа в месяце (если меньше нуля 
     // или больше длины месяца, тогда в календаре будет пропуск).
-    $n = - ($wday - 2);
+    $n = - ($wday != 0 ? $wday - 2 : 5);
     $cal = [];
     // Цикл по строкам.
     for ($y = 0; $y < 6; $y++) {
@@ -40,7 +41,7 @@
 
   // Формируем календарь на текущий месяц.
   $now = getdate();
-  $cal = makeCal($now['year'], $now['mon'] - 1);
+  $cal = makeCal($now['year'], $now['mon']);
 ?>
 <!DOCTYPE html>
 <html lang="ru">


### PR DESCRIPTION
В номере дня недели для 1 числа не учитывалось с каким месяцем была вызвана функция. Скрипт всегда брал день недели для текущего месяца хотя изначально функция была вызвана с предыдущим месяцем.
Так же скрипт работал не корректно если первый день недели воскресенье (т.е. номер дня недели = 0)