### PR TITLE
Update dumper.php

### DIFF
--- a/func/dumper.php
+++ b/func/dumper.php
@@ -24,7 +24,7 @@
     }
     $buf = $type; 
     $leftSp .= "    ";
-    for (Reset($obj); list($k, $v) = each($obj); ) {
+    foreach ($obj as $k => $v) {
       if ($k === "GLOBALS") continue;
       $buf .= "\n$leftSp$k => ".dumperGet($v, $leftSp);
     }


### PR DESCRIPTION
<b>Deprecated</b>:  The each() function is deprecated. This message will be suppressed on further calls in <b>[...][...]</b> on line <b>27</b>